### PR TITLE
:bug: :: requirements.txt 설치시 -r 플래그를 안넣어줬었음

### DIFF
--- a/.github/workflows/fitcloud-fee-bot.yml
+++ b/.github/workflows/fitcloud-fee-bot.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ./automation/discord-bot/fee-bot/requirements.txt
+          pip install -r ./automation/discord-bot/fee-bot/requirements.txt
       - name: Create .env
         run: |
           touch ./automation/discord-bot/fee-bot/.env


### PR DESCRIPTION
# 개요
pip install이 안되는 문제 해결
# 내용
pip install requirements.txt 명령어에 -r 플래그를 넣어줬음