### PR TITLE
🔀 :: 뇨파봇 백엔드 에러 로그 보기 기능 추가

### DIFF
--- a/automation/discord-bot/CD/android_bot.py
+++ b/automation/discord-bot/CD/android_bot.py
@@ -24,6 +24,9 @@ class Deploy(discord.ui.View):
     
     @discord.ui.button(label="안드로이드 배포", style=discord.ButtonStyle.green)
     async def android_deploy(self, interaction : discord.Interaction, button: discord.ui.Button):
+        global release_tag
+        global release_title
+        
         member = interaction.user
         channel = bot.get_channel(int(channel_url))
         await interaction.response.send_message(content = "릴리즈 타이틀을 작성해줘.")
@@ -39,8 +42,8 @@ class Deploy(discord.ui.View):
                     message = await bot.wait_for("message", check=lambda m: m.author == member and m.channel == channel, timeout=30.0)
                 except asyncio.TimeoutError:
                     await message.channel.send("30초가 지났어. 명령어를 다시 실행시켜줘.")
-                    release_tag = message.content
                 else:
+                    release_tag = message.content
                     await message.channel.send(content = "뇨 ~ Default 브랜치로 CD를 진행할게. 무사히 올라가길 같이 기도해줘.")
                     os.system(f'gh release create {release_tag} --repo=GSM-MSG/SMS-Android --title={release_title} --generate-notes')
                 break

--- a/automation/discord-bot/CD/nyopa_bot.py
+++ b/automation/discord-bot/CD/nyopa_bot.py
@@ -1,0 +1,56 @@
+from discord.ext import commands
+from dotenv import load_dotenv
+import discord
+import asyncio
+import os
+
+
+bot = commands.Bot(command_prefix='!', intents=discord.Intents.all())
+
+load_dotenv()
+token = os.getenv("token")
+channel_url = os.getenv("channel")
+
+@bot.event
+async def on_ready():
+    print("I'm ready")
+
+@bot.command()
+async def 뇨파(ctx):
+    view = Deploy()
+    await ctx.reply("뇨~ 뭘 도와줄까?",view=view)
+
+class Deploy(discord.ui.View):
+    @discord.ui.button(label="안드로이드 배포", style=discord.ButtonStyle.green)
+    async def android_deploy(self, interaction : discord.Interaction, button: discord.ui.Button):
+        global release_tag
+        global release_title
+        
+        member = interaction.user
+        channel = bot.get_channel(int(channel_url))
+        await interaction.response.send_message(content = "릴리즈 타이틀을 작성해줘.")
+        while(True):
+            try: 
+                message = await bot.wait_for("message", check=lambda m: m.author == member and m.channel == channel, timeout=30.0)
+            except asyncio.TimeoutError:
+                await message.channel.send("30초가 지났어. 명령어를 다시 실행시켜줘.")
+            else:
+                release_title  = message.content
+                await message.channel.send(content = "릴리즈 태그를 작성해줘.")
+                try: 
+                    message = await bot.wait_for("message", check=lambda m: m.author == member and m.channel == channel, timeout=30.0)
+                except asyncio.TimeoutError:
+                    await message.channel.send("30초가 지났어. 명령어를 다시 실행시켜줘.")
+                else:
+                    release_tag = message.content
+                    await message.channel.send(content = "뇨 ~ Default 브랜치로 CD를 진행할게. 무사히 올라가길 같이 기도해줘.")
+                    os.system(f'gh release create {release_tag} --repo=GSM-MSG/SMS-Android --title={release_title} --generate-notes')
+                break
+
+    @discord.ui.button(label="백엔드 로그보기", style=discord.ButtonStyle.blurple)
+    async def backend_log(self, interaction : discord.Interaction, button: discord.ui.Button):
+        await interaction.response.send_message(content = "테스트")
+
+
+
+bot.run(token)

--- a/automation/discord-bot/CD/nyopa_bot.py
+++ b/automation/discord-bot/CD/nyopa_bot.py
@@ -55,15 +55,15 @@ class Deploy(discord.ui.View):
         dict_log = json.loads(log_data)
         
         test = []
-        stringtest = ''
+        error_log = ''
 
         for i in dict_log["events"]:
             test.append(i["message"].split(" : ")[1])
 
         for i in test[:12]:
-                stringtest = stringtest + i + '\n'
+                error_log = error_log + i + '\n'
 
-        await interaction.response.send_message(content = stringtest)
+        await interaction.response.send_message(content = error_log)
 
 
 

--- a/automation/discord-bot/CD/nyopa_bot.py
+++ b/automation/discord-bot/CD/nyopa_bot.py
@@ -49,7 +49,7 @@ class Deploy(discord.ui.View):
                     os.system(f'gh release create {release_tag} --repo=GSM-MSG/SMS-Android --title={release_title} --generate-notes')
                 break
 
-    @discord.ui.button(label="백엔드 로그보기", style=discord.ButtonStyle.blurple)
+    @discord.ui.button(label="백엔드 ERROR 로그보기", style=discord.ButtonStyle.red)
     async def backend_log(self, interaction : discord.Interaction, button: discord.ui.Button):
         log_data = subprocess.check_output('aws logs filter-log-events --log-group-name sms-logs --log-stream-names i-02468f866c3293595 --filter-pattern ERROR'.split(" "))
         dict_log = json.loads(log_data)

--- a/automation/discord-bot/CD/nyopa_bot.py
+++ b/automation/discord-bot/CD/nyopa_bot.py
@@ -3,7 +3,9 @@ from dotenv import load_dotenv
 import discord
 import asyncio
 import os
-
+import json
+import subprocess
+from pprint import pprint
 
 bot = commands.Bot(command_prefix='!', intents=discord.Intents.all())
 
@@ -49,7 +51,19 @@ class Deploy(discord.ui.View):
 
     @discord.ui.button(label="백엔드 로그보기", style=discord.ButtonStyle.blurple)
     async def backend_log(self, interaction : discord.Interaction, button: discord.ui.Button):
-        await interaction.response.send_message(content = "테스트")
+        log_data = subprocess.check_output('aws logs filter-log-events --log-group-name sms-logs --log-stream-names i-02468f866c3293595 --filter-pattern ERROR'.split(" "))
+        dict_log = json.loads(log_data)
+        
+        test = []
+        stringtest = ''
+
+        for i in dict_log["events"]:
+            test.append(i["message"].split(" : ")[1])
+
+        for i in test[:12]:
+                stringtest = stringtest + i + '\n'
+
+        await interaction.response.send_message(content = stringtest)
 
 
 

--- a/automation/discord-bot/CD/nyopa_bot.py
+++ b/automation/discord-bot/CD/nyopa_bot.py
@@ -60,7 +60,7 @@ class Deploy(discord.ui.View):
         for i in dict_log["events"]:
             test.append(i["message"].split(" : ")[1])
 
-        for i in test[:12]:
+        for i in test[:20]:
                 error_log = error_log + i + '\n'
 
         await interaction.response.send_message(content = error_log)


### PR DESCRIPTION
## 개요 
뇨파 봇 백엔드 에러 로그 보기 기능 추가

## 기능
awscli 를 통해 cloudwatch agent로 긁은 error 필터링된 로그들을 출력합니다.
<img width="955" alt="image" src="https://github.com/GSM-MSG/SMS-DevOps/assets/82383294/1179a585-d3b8-44f3-8df0-a52d11b18de3">
